### PR TITLE
Printing cleaner images list

### DIFF
--- a/pkg/cmd/darch/commands/images/list.go
+++ b/pkg/cmd/darch/commands/images/list.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"text/tabwriter"
 
+	"github.com/containerd/containerd/pkg/progress"
 	"github.com/godarch/darch/pkg/repository"
 	"github.com/urfave/cli"
 )
@@ -41,9 +42,18 @@ var listCommand = cli.Command{
 		}
 
 		tw := tabwriter.NewWriter(os.Stdout, 1, 8, 2, ' ', 0)
-		fmt.Fprintln(tw, "REPOSITORY\tTAG\tCREATED\t")
+		fmt.Fprintln(tw, "REPOSITORY\tTAG\tCREATED\tSIZE\t")
 		for _, img := range imgs {
-			fmt.Fprintf(tw, "%v\t%v\t%v\t\n", img.Name, img.Tag, img.CreatedAt.Format("2006-01-02"))
+			size, err := repo.GetImageSize(context.Background(), fmt.Sprintf("%s:%s", img.Name, img.Tag))
+			if err != nil {
+				return err
+			}
+
+			fmt.Fprintf(tw, "%v\t%v\t%v\t%v\t\n",
+				img.Name,
+				img.Tag,
+				img.CreatedAt.Format("2006-01-02"),
+				progress.Bytes(size))
 		}
 
 		return tw.Flush()

--- a/pkg/cmd/darch/commands/images/list.go
+++ b/pkg/cmd/darch/commands/images/list.go
@@ -3,6 +3,8 @@ package images
 import (
 	"context"
 	"fmt"
+	"os"
+	"text/tabwriter"
 
 	"github.com/godarch/darch/pkg/repository"
 	"github.com/urfave/cli"
@@ -11,7 +13,14 @@ import (
 var listCommand = cli.Command{
 	Name:  "list",
 	Usage: "list images",
+	Flags: []cli.Flag{
+		cli.BoolFlag{
+			Name:  "quiet, q",
+			Usage: "print only the image refs",
+		},
+	},
 	Action: func(clicontext *cli.Context) error {
+		quiet := clicontext.Bool("quiet")
 
 		repo, err := repository.NewSession(repository.DefaultContainerdSocketLocation)
 		if err != nil {
@@ -24,10 +33,19 @@ var listCommand = cli.Command{
 			return err
 		}
 
-		for _, img := range imgs {
-			fmt.Println(img.Name + ":" + img.Tag)
+		if quiet {
+			for _, img := range imgs {
+				fmt.Println(img.Name + ":" + img.Tag)
+			}
+			return nil
 		}
 
-		return nil
+		tw := tabwriter.NewWriter(os.Stdout, 1, 8, 2, ' ', 0)
+		fmt.Fprintln(tw, "REPOSITORY\tTAG\tCREATED\t")
+		for _, img := range imgs {
+			fmt.Fprintf(tw, "%v\t%v\t%v\t\n", img.Name, img.Tag, img.CreatedAt.Format("2006-01-02"))
+		}
+
+		return tw.Flush()
 	},
 }

--- a/pkg/repository/images.go
+++ b/pkg/repository/images.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"context"
+	"github.com/containerd/containerd/platforms"
 	"time"
 
 	"github.com/containerd/containerd/errdefs"
@@ -41,6 +42,18 @@ func (session *Session) GetImages(ctx context.Context) ([]Image, error) {
 	}
 
 	return result, nil
+}
+
+// GetImageSize Returns the size of an image.
+func (session *Session) GetImageSize(ctx context.Context, name string) (int64, error) {
+	ctx = namespaces.WithNamespace(ctx, "darch")
+
+	img, err := session.client.ImageService().Get(ctx, name)
+	if err != nil {
+		return -1, err
+	}
+
+	return img.Size(ctx, session.client.ContentStore(), platforms.Default())
 }
 
 // TagImage Tag an image.

--- a/vendor.conf
+++ b/vendor.conf
@@ -19,6 +19,7 @@ github.com/gogo/protobuf v1.0.0
 github.com/gogo/googleapis 08a7655d27152912db7aaf4f983275eaf8d128ef
 github.com/gobwas/glob 51eb1ee00b6d931c66d229ceeb7c31b985563420
 github.com/docker/go-events 9461782956ad83b30282bf90e31fa6a70c255ba9
+github.com/docker/go-units v0.3.1
 github.com/docker/distribution b38e5838b7b2f2ad48e06ec4b500011976080621
 github.com/docker/docker 86f080cff0914e9694068ed78d503701667c4c00
 github.com/containerd/console c12b1e7919c14469339a5d38f2f8ed9b64a9de23

--- a/vendor/github.com/containerd/containerd/pkg/progress/bar.go
+++ b/vendor/github.com/containerd/containerd/pkg/progress/bar.go
@@ -1,0 +1,82 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package progress
+
+import (
+	"bytes"
+	"fmt"
+)
+
+// TODO(stevvooe): We may want to support more interesting parameterization of
+// the bar. For now, it is very simple.
+
+// Bar provides a very simple progress bar implementation.
+//
+// Use with fmt.Printf and "r" to format the progress bar. A "-" flag makes it
+// progress from right to left.
+type Bar float64
+
+var _ fmt.Formatter = Bar(1.0)
+
+// Format the progress bar as output
+func (h Bar) Format(state fmt.State, r rune) {
+	switch r {
+	case 'r':
+	default:
+		panic(fmt.Sprintf("%v: unexpected format character", float64(h)))
+	}
+
+	if h > 1.0 {
+		h = 1.0
+	}
+
+	if h < 0.0 {
+		h = 0.0
+	}
+
+	if state.Flag('-') {
+		h = 1.0 - h
+	}
+
+	width, ok := state.Width()
+	if !ok {
+		// default width of 40
+		width = 40
+	}
+
+	var pad int
+
+	extra := len([]byte(green)) + len([]byte(reset))
+
+	p := make([]byte, width+extra)
+	p[0], p[len(p)-1] = '|', '|'
+	pad += 2
+
+	positive := int(Bar(width-pad) * h)
+	negative := width - pad - positive
+
+	n := 1
+	n += copy(p[n:], []byte(green))
+	n += copy(p[n:], bytes.Repeat([]byte("+"), positive))
+	n += copy(p[n:], []byte(reset))
+
+	if negative > 0 {
+		copy(p[n:len(p)-1], bytes.Repeat([]byte("-"), negative))
+	}
+
+	state.Write(p)
+}

--- a/vendor/github.com/containerd/containerd/pkg/progress/doc.go
+++ b/vendor/github.com/containerd/containerd/pkg/progress/doc.go
@@ -1,0 +1,18 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+// Package progress assists in displaying human readable progress information.
+package progress

--- a/vendor/github.com/containerd/containerd/pkg/progress/escape.go
+++ b/vendor/github.com/containerd/containerd/pkg/progress/escape.go
@@ -1,0 +1,24 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package progress
+
+const (
+	escape = "\x1b"
+	reset  = escape + "[0m"
+	red    = escape + "[31m" // nolint: unused, varcheck
+	green  = escape + "[32m"
+)

--- a/vendor/github.com/containerd/containerd/pkg/progress/humaans.go
+++ b/vendor/github.com/containerd/containerd/pkg/progress/humaans.go
@@ -1,0 +1,45 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package progress
+
+import (
+	"fmt"
+	"time"
+
+	units "github.com/docker/go-units"
+)
+
+// Bytes converts a regular int64 to human readable type.
+type Bytes int64
+
+// String returns the string representation of bytes
+func (b Bytes) String() string {
+	return units.CustomSize("%02.1f %s", float64(b), 1024.0, []string{"B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB", "ZiB", "YiB"})
+}
+
+// BytesPerSecond is the rate in seconds for byte operations
+type BytesPerSecond int64
+
+// NewBytesPerSecond returns the rate that n bytes were written in the provided duration
+func NewBytesPerSecond(n int64, duration time.Duration) BytesPerSecond {
+	return BytesPerSecond(float64(n) / duration.Seconds())
+}
+
+// String returns the string representation of the rate
+func (bps BytesPerSecond) String() string {
+	return fmt.Sprintf("%v/s", Bytes(bps))
+}

--- a/vendor/github.com/containerd/containerd/pkg/progress/writer.go
+++ b/vendor/github.com/containerd/containerd/pkg/progress/writer.go
@@ -1,0 +1,115 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package progress
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"regexp"
+	"strings"
+
+	"github.com/containerd/console"
+)
+
+var (
+	regexCleanLine = regexp.MustCompile("\x1b\\[[0-9]+m[\x1b]?")
+)
+
+// Writer buffers writes until flush, at which time the last screen is cleared
+// and the current buffer contents are written. This is useful for
+// implementing progress displays, such as those implemented in docker and
+// git.
+type Writer struct {
+	buf   bytes.Buffer
+	w     io.Writer
+	lines int
+}
+
+// NewWriter returns a writer
+func NewWriter(w io.Writer) *Writer {
+	return &Writer{
+		w: w,
+	}
+}
+
+// Write the provided bytes
+func (w *Writer) Write(p []byte) (n int, err error) {
+	return w.buf.Write(p)
+}
+
+// Flush should be called when refreshing the current display.
+func (w *Writer) Flush() error {
+	if w.buf.Len() == 0 {
+		return nil
+	}
+
+	if err := w.clearLines(); err != nil {
+		return err
+	}
+	w.lines = countLines(w.buf.String())
+
+	if _, err := w.w.Write(w.buf.Bytes()); err != nil {
+		return err
+	}
+
+	w.buf.Reset()
+	return nil
+}
+
+// TODO(stevvooe): The following are system specific. Break these out if we
+// decide to build this package further.
+
+func (w *Writer) clearLines() error {
+	for i := 0; i < w.lines; i++ {
+		if _, err := fmt.Fprintf(w.w, "\x1b[1A\x1b[2K\r"); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// countLines in the output. If a line is longer than the console width then
+// an extra line is added to the count for each wrapped line. If the console
+// width is undefined then 0 is returned so that no lines are cleared on the next
+// flush.
+func countLines(output string) int {
+	con, err := console.ConsoleFromFile(os.Stdin)
+	if err != nil {
+		return 0
+	}
+	ws, err := con.Size()
+	if err != nil {
+		return 0
+	}
+	width := int(ws.Width)
+	if width <= 0 {
+		return 0
+	}
+	strlines := strings.Split(output, "\n")
+	lines := -1
+	for _, line := range strlines {
+		lines += (len(stripLine(line))-1)/width + 1
+	}
+	return lines
+}
+
+func stripLine(line string) string {
+	return string(regexCleanLine.ReplaceAll([]byte(line), []byte{}))
+}

--- a/vendor/github.com/docker/go-units/LICENSE
+++ b/vendor/github.com/docker/go-units/LICENSE
@@ -1,0 +1,191 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        https://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2015 Docker, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       https://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/docker/go-units/README.md
+++ b/vendor/github.com/docker/go-units/README.md
@@ -1,0 +1,16 @@
+[![GoDoc](https://godoc.org/github.com/docker/go-units?status.svg)](https://godoc.org/github.com/docker/go-units)
+
+# Introduction
+
+go-units is a library to transform human friendly measurements into machine friendly values.
+
+## Usage
+
+See the [docs in godoc](https://godoc.org/github.com/docker/go-units) for examples and documentation.
+
+## Copyright and license
+
+Copyright © 2015 Docker, Inc.
+
+go-units is licensed under the Apache License, Version 2.0.
+See [LICENSE](LICENSE) for the full text of the license.

--- a/vendor/github.com/docker/go-units/duration.go
+++ b/vendor/github.com/docker/go-units/duration.go
@@ -1,0 +1,33 @@
+// Package units provides helper function to parse and print size and time units
+// in human-readable format.
+package units
+
+import (
+	"fmt"
+	"time"
+)
+
+// HumanDuration returns a human-readable approximation of a duration
+// (eg. "About a minute", "4 hours ago", etc.).
+func HumanDuration(d time.Duration) string {
+	if seconds := int(d.Seconds()); seconds < 1 {
+		return "Less than a second"
+	} else if seconds < 60 {
+		return fmt.Sprintf("%d seconds", seconds)
+	} else if minutes := int(d.Minutes()); minutes == 1 {
+		return "About a minute"
+	} else if minutes < 60 {
+		return fmt.Sprintf("%d minutes", minutes)
+	} else if hours := int(d.Hours()); hours == 1 {
+		return "About an hour"
+	} else if hours < 48 {
+		return fmt.Sprintf("%d hours", hours)
+	} else if hours < 24*7*2 {
+		return fmt.Sprintf("%d days", hours/24)
+	} else if hours < 24*30*3 {
+		return fmt.Sprintf("%d weeks", hours/24/7)
+	} else if hours < 24*365*2 {
+		return fmt.Sprintf("%d months", hours/24/30)
+	}
+	return fmt.Sprintf("%d years", int(d.Hours())/24/365)
+}

--- a/vendor/github.com/docker/go-units/size.go
+++ b/vendor/github.com/docker/go-units/size.go
@@ -1,0 +1,96 @@
+package units
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// See: http://en.wikipedia.org/wiki/Binary_prefix
+const (
+	// Decimal
+
+	KB = 1000
+	MB = 1000 * KB
+	GB = 1000 * MB
+	TB = 1000 * GB
+	PB = 1000 * TB
+
+	// Binary
+
+	KiB = 1024
+	MiB = 1024 * KiB
+	GiB = 1024 * MiB
+	TiB = 1024 * GiB
+	PiB = 1024 * TiB
+)
+
+type unitMap map[string]int64
+
+var (
+	decimalMap = unitMap{"k": KB, "m": MB, "g": GB, "t": TB, "p": PB}
+	binaryMap  = unitMap{"k": KiB, "m": MiB, "g": GiB, "t": TiB, "p": PiB}
+	sizeRegex  = regexp.MustCompile(`^(\d+(\.\d+)*) ?([kKmMgGtTpP])?[bB]?$`)
+)
+
+var decimapAbbrs = []string{"B", "kB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"}
+var binaryAbbrs = []string{"B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB", "ZiB", "YiB"}
+
+// CustomSize returns a human-readable approximation of a size
+// using custom format.
+func CustomSize(format string, size float64, base float64, _map []string) string {
+	i := 0
+	unitsLimit := len(_map) - 1
+	for size >= base && i < unitsLimit {
+		size = size / base
+		i++
+	}
+	return fmt.Sprintf(format, size, _map[i])
+}
+
+// HumanSize returns a human-readable approximation of a size
+// capped at 4 valid numbers (eg. "2.746 MB", "796 KB").
+func HumanSize(size float64) string {
+	return CustomSize("%.4g %s", size, 1000.0, decimapAbbrs)
+}
+
+// BytesSize returns a human-readable size in bytes, kibibytes,
+// mebibytes, gibibytes, or tebibytes (eg. "44kiB", "17MiB").
+func BytesSize(size float64) string {
+	return CustomSize("%.4g %s", size, 1024.0, binaryAbbrs)
+}
+
+// FromHumanSize returns an integer from a human-readable specification of a
+// size using SI standard (eg. "44kB", "17MB").
+func FromHumanSize(size string) (int64, error) {
+	return parseSize(size, decimalMap)
+}
+
+// RAMInBytes parses a human-readable string representing an amount of RAM
+// in bytes, kibibytes, mebibytes, gibibytes, or tebibytes and
+// returns the number of bytes, or -1 if the string is unparseable.
+// Units are case-insensitive, and the 'b' suffix is optional.
+func RAMInBytes(size string) (int64, error) {
+	return parseSize(size, binaryMap)
+}
+
+// Parses the human-readable size string into the amount it represents.
+func parseSize(sizeStr string, uMap unitMap) (int64, error) {
+	matches := sizeRegex.FindStringSubmatch(sizeStr)
+	if len(matches) != 4 {
+		return -1, fmt.Errorf("invalid size: '%s'", sizeStr)
+	}
+
+	size, err := strconv.ParseFloat(matches[1], 64)
+	if err != nil {
+		return -1, err
+	}
+
+	unitPrefix := strings.ToLower(matches[3])
+	if mul, ok := uMap[unitPrefix]; ok {
+		size *= float64(mul)
+	}
+
+	return int64(size), nil
+}

--- a/vendor/github.com/docker/go-units/ulimit.go
+++ b/vendor/github.com/docker/go-units/ulimit.go
@@ -1,0 +1,118 @@
+package units
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// Ulimit is a human friendly version of Rlimit.
+type Ulimit struct {
+	Name string
+	Hard int64
+	Soft int64
+}
+
+// Rlimit specifies the resource limits, such as max open files.
+type Rlimit struct {
+	Type int    `json:"type,omitempty"`
+	Hard uint64 `json:"hard,omitempty"`
+	Soft uint64 `json:"soft,omitempty"`
+}
+
+const (
+	// magic numbers for making the syscall
+	// some of these are defined in the syscall package, but not all.
+	// Also since Windows client doesn't get access to the syscall package, need to
+	//	define these here
+	rlimitAs         = 9
+	rlimitCore       = 4
+	rlimitCPU        = 0
+	rlimitData       = 2
+	rlimitFsize      = 1
+	rlimitLocks      = 10
+	rlimitMemlock    = 8
+	rlimitMsgqueue   = 12
+	rlimitNice       = 13
+	rlimitNofile     = 7
+	rlimitNproc      = 6
+	rlimitRss        = 5
+	rlimitRtprio     = 14
+	rlimitRttime     = 15
+	rlimitSigpending = 11
+	rlimitStack      = 3
+)
+
+var ulimitNameMapping = map[string]int{
+	//"as":         rlimitAs, // Disabled since this doesn't seem usable with the way Docker inits a container.
+	"core":       rlimitCore,
+	"cpu":        rlimitCPU,
+	"data":       rlimitData,
+	"fsize":      rlimitFsize,
+	"locks":      rlimitLocks,
+	"memlock":    rlimitMemlock,
+	"msgqueue":   rlimitMsgqueue,
+	"nice":       rlimitNice,
+	"nofile":     rlimitNofile,
+	"nproc":      rlimitNproc,
+	"rss":        rlimitRss,
+	"rtprio":     rlimitRtprio,
+	"rttime":     rlimitRttime,
+	"sigpending": rlimitSigpending,
+	"stack":      rlimitStack,
+}
+
+// ParseUlimit parses and returns a Ulimit from the specified string.
+func ParseUlimit(val string) (*Ulimit, error) {
+	parts := strings.SplitN(val, "=", 2)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid ulimit argument: %s", val)
+	}
+
+	if _, exists := ulimitNameMapping[parts[0]]; !exists {
+		return nil, fmt.Errorf("invalid ulimit type: %s", parts[0])
+	}
+
+	var (
+		soft int64
+		hard = &soft // default to soft in case no hard was set
+		temp int64
+		err  error
+	)
+	switch limitVals := strings.Split(parts[1], ":"); len(limitVals) {
+	case 2:
+		temp, err = strconv.ParseInt(limitVals[1], 10, 64)
+		if err != nil {
+			return nil, err
+		}
+		hard = &temp
+		fallthrough
+	case 1:
+		soft, err = strconv.ParseInt(limitVals[0], 10, 64)
+		if err != nil {
+			return nil, err
+		}
+	default:
+		return nil, fmt.Errorf("too many limit value arguments - %s, can only have up to two, `soft[:hard]`", parts[1])
+	}
+
+	if soft > *hard {
+		return nil, fmt.Errorf("ulimit soft limit must be less than or equal to hard limit: %d > %d", soft, *hard)
+	}
+
+	return &Ulimit{Name: parts[0], Soft: soft, Hard: *hard}, nil
+}
+
+// GetRlimit returns the RLimit corresponding to Ulimit.
+func (u *Ulimit) GetRlimit() (*Rlimit, error) {
+	t, exists := ulimitNameMapping[u.Name]
+	if !exists {
+		return nil, fmt.Errorf("invalid ulimit name %s", u.Name)
+	}
+
+	return &Rlimit{Type: t, Soft: uint64(u.Soft), Hard: uint64(u.Hard)}, nil
+}
+
+func (u *Ulimit) String() string {
+	return fmt.Sprintf("%s=%d:%d", u.Name, u.Soft, u.Hard)
+}


### PR DESCRIPTION
fixes #10 

This produces the following output:
```
>> sudo darch images list
REPOSITORY      TAG     CREATED     SIZE
godarch/arch    latest  2019-02-14  153.1 MiB
godarch/ubuntu  latest  2019-02-16  359.6 MiB
```
```
>> sudo darch images list -q
godarch/arch:latest
godarch/ubuntu:latest
```

If we want to also print the image id (digest) and size we would need to one of the following (that I can think of).
1. Add those fields to the `Image` struct. Then in `session.GetImages()` we would need to call `containerd.Image.Size()` to calculate the size of each image. This would be unnecessarily expensive if you're not printing the table.
2. In the for loop printing the table call `session.client.ImageService().Get()` to get the original `containerd.Image` object for each image and then calculate the size.
3. Save the original `containerd.Image` in the `Image` struct.

What do you think?