### PR TITLE
Support alternative sort methods of stages

### DIFF
--- a/pkg/staging/parser.go
+++ b/pkg/staging/parser.go
@@ -4,7 +4,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"path"
+	"time"
 
 	"github.com/godarch/darch/pkg/reference"
 	"github.com/godarch/darch/pkg/utils"
@@ -18,6 +20,7 @@ type StagedImage struct {
 	InitRAMFS     string
 	RootFS        string
 	NoDoubleMount bool
+	CreationTime  time.Time
 }
 
 // StagedImageNamed A StagedImage with a name and tag
@@ -73,11 +76,17 @@ func parseImageDir(imageDir string) (StagedImage, error) {
 		return result, fmt.Errorf("rootfs was invalid")
 	}
 
+	stat, err := os.Stat(imageDir)
+	if err != nil {
+		return result, err
+	}
+
 	result.InitRAMFS = config.InitRAMFS
 	result.Kernel = config.Kernel
 	result.KernelParams = config.KernelParams
 	result.RootFS = config.RootFS
 	result.NoDoubleMount = config.NoDoubleMount
+	result.CreationTime = stat.ModTime()
 
 	return result, nil
 }

--- a/pkg/staging/sort.go
+++ b/pkg/staging/sort.go
@@ -1,9 +1,41 @@
 package staging
 
-// ByAge implements sort.Interface for []Person based on
-// the Age field.
-type sortStageImageNamed []StagedImageNamed
+// sortStageImageNamedByName implements sort.Interface for []StagedImageNamed
+// based on the FullName field in an ascending order.
+type sortStagedImageNamedByName []StagedImageNamed
 
-func (a sortStageImageNamed) Len() int           { return len(a) }
-func (a sortStageImageNamed) Less(i, j int) bool { return a[i].Ref.FullName() < a[j].Ref.FullName() }
-func (a sortStageImageNamed) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a sortStagedImageNamedByName) Len() int { return len(a) }
+func (a sortStagedImageNamedByName) Less(i, j int) bool {
+	return a[i].Ref.FullName() < a[j].Ref.FullName()
+}
+func (a sortStagedImageNamedByName) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+
+// sortStageImageNamedByNameDesc implements sort.Interface for []StagedImageNamed
+// based on the FullName field in an descending order.
+type sortStagedImageNamedByNameDesc []StagedImageNamed
+
+func (a sortStagedImageNamedByNameDesc) Len() int { return len(a) }
+func (a sortStagedImageNamedByNameDesc) Less(i, j int) bool {
+	return a[i].Ref.FullName() > a[j].Ref.FullName()
+}
+func (a sortStagedImageNamedByNameDesc) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+
+// sortStagedImageNamedByAge implements sort.Interface for []StagedImageNamed
+// based on the CreationTime field in an ascending order.
+type sortStagedImageNamedByAge []StagedImageNamed
+
+func (a sortStagedImageNamedByAge) Len() int { return len(a) }
+func (a sortStagedImageNamedByAge) Less(i, j int) bool {
+	return a[i].CreationTime.Before(a[j].CreationTime)
+}
+func (a sortStagedImageNamedByAge) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+
+// sortStagedImageNamedByAgeDesc implements sort.Interface for []StagedImageNamed
+// based on the CreationTime field in an descending order.
+type sortStagedImageNamedByAgeDesc []StagedImageNamed
+
+func (a sortStagedImageNamedByAgeDesc) Len() int { return len(a) }
+func (a sortStagedImageNamedByAgeDesc) Less(i, j int) bool {
+	return a[i].CreationTime.After(a[j].CreationTime)
+}
+func (a sortStagedImageNamedByAgeDesc) Swap(i, j int) { a[i], a[j] = a[j], a[i] }

--- a/pkg/staging/staging.go
+++ b/pkg/staging/staging.go
@@ -43,7 +43,7 @@ func (session *Session) GetAllStaged() ([]StagedImageNamed, error) {
 	}
 
 	// Sort the images.
-	sort.Sort(sortStageImageNamed(result))
+	sort.Sort(sortStagedImageNamedByName(result))
 
 	return result, nil
 }


### PR DESCRIPTION
Start of #35 

Will probably need to be set in config file. Although `darch stage list` and `darch stage upload` could also have cli flags but I'm not sure how they should look like.

`sort` that takes strings (`name`, `age`) and a boolean `desc` to activate descending order?