### PR TITLE
Fix by absolute path to core commands not found

### DIFF
--- a/scripts/gen-bootable-image.sh
+++ b/scripts/gen-bootable-image.sh
@@ -72,13 +72,13 @@ arch-chroot rootfs apt-get update
 arch-chroot rootfs apt-get -y install network-manager openssh-server
 
 # Install GRUB
-arch-chroot rootfs grub-install ${loop_device}
-arch-chroot rootfs grub-mkconfig -o /boot/grub/grub.cfg
+arch-chroot rootfs /sbin/grub-install ${loop_device}
+arch-chroot rootfs /sbin/grub-mkconfig -o /boot/grub/grub.cfg
 
 # Create the default users
 arch-chroot rootfs apt-get -y install sudo
 arch-chroot rootfs /usr/bin/bash -c 'echo -en "root\nroot" | passwd'
-arch-chroot rootfs useradd -m -G users,sudo -s /usr/bin/bash darch
+arch-chroot rootfs /sbin/useradd -m -G users,sudo -s /usr/bin/bash darch
 arch-chroot rootfs /usr/bin/bash -c 'echo -en "darch\ndarch" | passwd darch'
 
 # Install Darch


### PR DESCRIPTION
Fix for chroot: failed to run command ‘grub-install’: No such file or directory

Under Archlinux, the arch-chroot doesn't seem to have the /sbin/ in the path so grub-install, grub-mkconfig and useradd are not found during the image creation. Defining the absolute path fixes this.