### PR TITLE
Add Manifest support for multi-platform builds

### DIFF
--- a/pkg/repository/build.go
+++ b/pkg/repository/build.go
@@ -184,6 +184,13 @@ func (session *Session) createImageFromSnapshot(ctx context.Context, img contain
 		return err
 	}
 
+	if m.Descriptor().MediaType == images.MediaTypeDockerSchema2ManifestList {
+		m, err = manifest.LoadManifestFromList(ctx, image_to.Target(), contentStore, runtime.GOOS, runtime.GOARCH)
+		if err != nil {
+			return err
+		}
+	}
+
 	snapshot, err := session.snapshotter.Stat(ctx, activeSnapshotKey)
 	if err != nil {
 		return err


### PR DESCRIPTION
Hey! I am using some files from this project mainly for modifying images/manifests and I ran into problems when using images with multiple supported platforms, because when I use the LoadManifest() function the manifest returned is a list with all the manifests (mediatype is images.MediaTypeDockerSchema2ManifestList).

To this end, I created a function LoadManifestFromList() that extracts the manifest for a specific platform that can then be used normally. Example usage can be found in the build.go file where it is checked whether the manifest returned by LoadManifest() is a Manifest List and if it is the specific manifest for the runtime os and arch is loaded.

I'm not sure if this is needed for the recipe building or for the aims of this specific project in general, but I created this PR just in case any of this is useful, for my own aims this was needed :)

In any case, thank you for your contributions, this project was really helpful and provided some functionality I could not find anywhere else :)